### PR TITLE
feat: 愛鳥登録画面作成と登録画面への遷移ボタンを設置

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { BrowserRouter, Route, Routes } from 'react-router-dom';
 import BirdListPage from './components/page/BirdList/BirdList.page';
+import RecordCreatePage from './components/page/RecordCreate/RecordCreate-page';
 import RecordListPage from './components/page/RecordList/RecordList.page';
 import TopPage from './components/page/Top/Top.page';
 
@@ -10,6 +11,7 @@ const App: React.FC = () => (
       <Route path="/" element={<TopPage />} />
       <Route path="/records" element={<RecordListPage />} /> 
       <Route path= "/birds" element={<BirdListPage />} />
+      <Route path= "/records/create" element={<RecordCreatePage />} />
     </Routes>
   </BrowserRouter>
 );

--- a/src/components/page/RecordCreate/RecordCreate-page.tsx
+++ b/src/components/page/RecordCreate/RecordCreate-page.tsx
@@ -1,0 +1,13 @@
+import Footer from '../../ui/Footer';
+import Header from '../../ui/Header';
+import { RecordCreate } from './RecordCreate';
+
+const RecordCreatePage = () => (
+  <>
+    <Header />
+    <RecordCreate />
+    <Footer />
+  </>
+);
+
+export default RecordCreatePage;

--- a/src/components/page/RecordCreate/RecordCreate.tsx
+++ b/src/components/page/RecordCreate/RecordCreate.tsx
@@ -1,10 +1,16 @@
-import { Box, Heading } from '@chakra-ui/react';
+import { Box, Heading, Input, Button} from '@chakra-ui/react';
+import DatePicker, { registerLocale } from 'react-datepicker';
+import ja from 'date-fns/locale/ja';
 import { gql } from '@apollo/client';
+import React from 'react';
 import Panel from '../../ui/Panel';
+import Form from '../../ui/Form';
 import { useRecordListQuery } from '../../../generated/graphql';
 
+registerLocale('ja', ja);
+
 gql`
-  query BirdListQuery {
+  query RecordCreateQuery {
     bird(id: 1) {
       name
     }
@@ -12,6 +18,9 @@ gql`
 `;
 
 export const RecordCreate = () => {
+  const Today = new Date();
+  const [date, setDate] = React.useState(Today);
+
    const { loading, error } = useRecordListQuery();
 
   if (loading) return <p>Loading...</p>;
@@ -19,9 +28,34 @@ export const RecordCreate = () => {
 
   return (
     <Box bg="gray.100" p={4}>
-      <Heading size="md">愛鳥一覧</Heading>
+      <Heading size="md">愛鳥 登録</Heading>
       <Panel mt={4}>
-        <Box></Box>
+          <Box>
+            <Form
+              title="愛鳥名"
+              component={
+                <Input placeholder='愛鳥の名前' />
+              }
+            />
+          </Box>
+          <Box mt={{ base: 4, md: 4 }}>
+            <Form
+              title="誕生日" 
+              component={
+              <DatePicker 
+                locale='ja'
+                dateFormat="yyyy/MM/dd"
+                selected={date}
+                onChange={selectedDate => {setDate(selectedDate || Today)}}
+                customInput={
+                  <Input h="38px" backgroundColor="#FFF" minW={250} />
+                }
+              />}              
+            />
+          </Box>
+          <Box mt={{base: 8, md: 8}} align="center">
+            <Button as="a" href="/records" colorScheme="teal" size="lg" w="60">登録</Button>
+          </Box>
       </Panel>
     </Box>
   );

--- a/src/components/page/RecordCreate/RecordCreate.tsx
+++ b/src/components/page/RecordCreate/RecordCreate.tsx
@@ -1,0 +1,28 @@
+import { Box, Heading } from '@chakra-ui/react';
+import { gql } from '@apollo/client';
+import Panel from '../../ui/Panel';
+import { useRecordListQuery } from '../../../generated/graphql';
+
+gql`
+  query BirdListQuery {
+    bird(id: 1) {
+      name
+    }
+  }
+`;
+
+export const RecordCreate = () => {
+   const { loading, error } = useRecordListQuery();
+
+  if (loading) return <p>Loading...</p>;
+  if (error) return <p>Error :(</p>;
+
+  return (
+    <Box bg="gray.100" p={4}>
+      <Heading size="md">愛鳥一覧</Heading>
+      <Panel mt={4}>
+        <Box></Box>
+      </Panel>
+    </Box>
+  );
+};

--- a/src/components/page/RecordCreate/__test__/RecordCreate-test.tsx
+++ b/src/components/page/RecordCreate/__test__/RecordCreate-test.tsx
@@ -1,0 +1,10 @@
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import RecordCreatePage from '../RecordCreate-page';
+
+describe('Top', () => {
+  it('愛鳥登録画面を表示する', () => {
+    render(<RecordCreatePage />);
+    expect(screen.getByText('愛鳥 登録')).toBeInTheDocument();
+  });
+});

--- a/src/components/page/RecordList/RecordList.tsx
+++ b/src/components/page/RecordList/RecordList.tsx
@@ -1,4 +1,4 @@
-import { Box, Heading, Input } from '@chakra-ui/react';
+import { Box, Heading, Input, Button } from '@chakra-ui/react';
 import DatePicker, { registerLocale } from 'react-datepicker';
 import ja from 'date-fns/locale/ja';
 import { startOfMonth } from 'date-fns';
@@ -100,6 +100,9 @@ export const RecordList = () => {
                 />
               }
             />
+          </Box>
+          <Box mt={{ md: 8}} ml={{md: 6}} >
+            <Button as="a" href="/records/create" colorScheme="teal" size="lg">作成</Button>
           </Box>
         </Box>
         <RecordListTable />


### PR DESCRIPTION
1 | 変更の概要 | 愛鳥登録画面作成、登録画面への遷移ボタンを設置
2 | なぜこの変更をするのか |
3| 変更内容 | 愛鳥登録画面に項目作成、記録一覧画面に登録画面への遷移ボタン設置
4 | やらないこと | レイアウトの調整
5 | 影響範囲 |　
6 | 操作方法 |・ 記録一覧画面から作成ボタンをクリックすることで登録画面に遷移する
　　　　　　・ 登録画面での記入項目確認
7 | 課題 | 項目部分のレイアウト、今後追加していく項目について
8 | 備考 |